### PR TITLE
PR 2 - Refactor the component architecture and filter data on the API

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,0 @@
-#DATABASE_URL=postgresql://postgres:password@localhost/solaceassignment

--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ yarn-error.log*
 
 # local env files
 .env*.local
+.env
 
 # vercel
 .vercel

--- a/DISCUSSION.md
+++ b/DISCUSSION.md
@@ -15,9 +15,7 @@ Since there was a search input to filter the advocate list, I think it was impor
 
 I realized that to improve performance on the backend, we need to filter at the query level. This proved a little bit tricky due to my inexperience with drizzle-orm. Eventually I arrived at the solution that is satisfactory considering the time-constraints. If I had more time, I would improve it such that even the phone numbers are searchable; currently that doesn't work. 
 
-### Issues
-
-A few of the queries I tried before settling on the current one:
+Some of my naive attempts are filtering at the SQL query  level before settling on the current approach:
 
 ```
 const data = await db
@@ -31,6 +29,8 @@ const data = await db
         .or(ilike(advocates.specialties, `%${searchQuery}%`))
         .or(ilike(advocates.yearsOfExperience, `%${searchQuery}%`))
     );
+```
+```
   const data = await db.query.advocates.findMany({
     where: or(
       ilike(advocates.firstName, `%${searchQuery}%`),
@@ -43,10 +43,11 @@ const data = await db
     ),
   });
 ```
+### Issues
 
 Also had trouble generating indexes in order to do full-text search:
 
-The below format even though it satisfied the TS error, it did not generate the indexes. when running npx drizzle-kit generate or npx drizzle-kit push
+The drizzle-orm documentation mentioned a different format (currently used) but that resulted in a TypeScript error. I tried to solve the TS error and was able to by using the below format. However, this did not generate the indexes. when running `npx drizzle-kit generate` or `npx drizzle-kit push`. So, based on a linked issue on the drizzle repository, I reverted to the format in the documentation and sure enough, the indexes were generated. I disabled the TS error with a note.
 
 ```
   (table) => ({

--- a/DISCUSSION.md
+++ b/DISCUSSION.md
@@ -1,0 +1,68 @@
+# Discussion
+
+## Improving performance on the frontend
+
+### Notes
+
+The original code was only relying on client-side requests for the advocate list. A quick to improve performance was to make use of react server components (comes with next) to fetch the advocate list and have it ready for the client side components as soon as they mount to the DOM (at least on the initial render).
+
+Since there was a search input to filter the advocate list, I think it was important to append the search query to the URL as a search parameters. This way, if the app is reloaded, the server component can use the search params in the URL to filter the advocate list at the SQL query level. 
+
+
+## Improving performance on the backend
+
+### Notes
+
+I realized that to improve performance on the backend, we need to filter at the query level. This proved a little bit tricky due to my inexperience with drizzle-orm. Eventually I arrived at the solution that is satisfactory considering the time-constraints. If I had more time, I would improve it such that even the phone numbers are searchable; currently that doesn't work. 
+
+### Issues
+
+A few of the queries I tried before settling on the current one:
+
+```
+const data = await db
+    .select()
+    .from(advocates)
+    .where(
+      ilike(advocates.firstName, `%${searchQuery}%`)
+        .or(ilike(advocates.lastName, `%${searchQuery}%`))
+        .or(ilike(advocates.city, `%${searchQuery}%`))
+        .or(ilike(advocates.degree, `%${searchQuery}%`))
+        .or(ilike(advocates.specialties, `%${searchQuery}%`))
+        .or(ilike(advocates.yearsOfExperience, `%${searchQuery}%`))
+    );
+  const data = await db.query.advocates.findMany({
+    where: or(
+      ilike(advocates.firstName, `%${searchQuery}%`),
+      ilike(advocates.lastName, `%${searchQuery}%`),
+      ilike(advocates.city, `%${searchQuery}%`),
+      ilike(advocates.degree, `%${searchQuery}%`),
+      ilike(advocates.specialties, `%${searchQuery}%`),
+      ilike(advocates.yearsOfExperience, `%${searchQuery}%`),
+      ilike(advocates.phoneNumber, `%${searchQuery}%`)
+    ),
+  });
+```
+
+Also had trouble generating indexes in order to do full-text search:
+
+The below format even though it satisfied the TS error, it did not generate the indexes. when running npx drizzle-kit generate or npx drizzle-kit push
+
+```
+  (table) => ({
+     indexes: [
+       index("search_index").using(
+         "gin",
+          sql`(
+             setweight(to_tsvector('english', ${table.firstName}), 'A') ||
+             setweight(to_tsvector('english', ${table.lastName}), 'A') ||
+             setweight(to_tsvector('english', ${table.city}), 'B') ||
+             setweight(to_tsvector('english', ${table.degree}), 'B') ||
+             setweight(to_tsvector('english', ${table.specialties}), 'C') ||
+             setweight(to_tsvector('english', ${table.yearsOfExperience}), 'D') ||
+             setweight(to_tsvector('english', ${table.phoneNumber}), 'D')
+         )`
+       ),
+     ],
+  })
+```

--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -1,11 +1,13 @@
-const config = {
+import 'dotenv/config';
+import { defineConfig } from 'drizzle-kit';
+
+export default defineConfig({
   dialect: "postgresql",
   schema: "./src/db/schema.ts",
+  out: './src/db/migrations', // Adjust path to your migrations folder
   dbCredentials: {
-    url: process.env.DATABASE_URL,
+    url: process.env.DATABASE_URL ?? '',
   },
   verbose: true,
   strict: true,
-};
-
-export default config;
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "solace-candidate-assignment",
       "version": "0.1.0",
       "dependencies": {
+        "dotenv": "^17.2.1",
         "drizzle-orm": "^0.32.1",
         "next": "^14.2.19",
         "postgres": "^3.4.4",
@@ -2093,6 +2094,18 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "17.2.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.1.tgz",
+      "integrity": "sha512-kQhDYKZecqnM0fCnzI5eIv5L4cAe/iRI+HqMbO/hbRdTAeXDG+M9FjipUxNfbARuEg4iHIbhnhs78BCHNbSxEQ==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/drizzle-kit": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,8 @@
         "next": "^14.2.19",
         "postgres": "^3.4.4",
         "react": "^18.3.1",
-        "react-dom": "^18.3.1"
+        "react-dom": "^18.3.1",
+        "use-debounce": "^10.0.5"
       },
       "devDependencies": {
         "@types/node": "^20.14.12",
@@ -5635,6 +5636,18 @@
       "dev": true,
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/use-debounce": {
+      "version": "10.0.5",
+      "resolved": "https://registry.npmjs.org/use-debounce/-/use-debounce-10.0.5.tgz",
+      "integrity": "sha512-Q76E3lnIV+4YT9AHcrHEHYmAd9LKwUAbPXDm7FlqVGDHiSOhX3RDjT8dm0AxbJup6WgOb1YEcKyCr11kBJR5KQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "peerDependencies": {
+        "react": "*"
       }
     },
     "node_modules/util-deprecate": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "next": "^14.2.19",
     "postgres": "^3.4.4",
     "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react-dom": "^18.3.1",
+    "use-debounce": "^10.0.5"
   },
   "devDependencies": {
     "@types/node": "^20.14.12",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "seed": "node --loader esbuild-register/loader -r esbuild-register ./src/db/seed/index.ts"
   },
   "dependencies": {
+    "dotenv": "^17.2.1",
     "drizzle-orm": "^0.32.1",
     "next": "^14.2.19",
     "postgres": "^3.4.4",

--- a/src/app/api/advocates/route.ts
+++ b/src/app/api/advocates/route.ts
@@ -6,7 +6,6 @@ import { sql } from "drizzle-orm";
 export async function GET(request: NextRequest) {
   const searchParams = request.nextUrl.searchParams;
   const searchQuery = searchParams.get("searchTerm") ?? "";
-  console.log("Search Query:", searchQuery);
 
   try {
     if (!searchQuery) {
@@ -23,10 +22,8 @@ export async function GET(request: NextRequest) {
       setweight(to_tsvector('english', ${advocates.phoneNumber}::text), 'D')
       @@ to_tsquery('english', ${searchQuery})
     )`);
-    console.log("New Data:", { newData: data });
     return NextResponse.json({ data, status: 200, ok: true });
   } catch (error) {
-    console.log("Route handler error when fetching newData: ", error);
     return NextResponse.json({ data: null, error: "Failed to fetch advocates", status: 500 });
   }
 }

--- a/src/app/api/advocates/route.ts
+++ b/src/app/api/advocates/route.ts
@@ -1,12 +1,9 @@
 import db from "../../../db";
 import { advocates } from "../../../db/schema";
-import { advocateData } from "../../../db/seed/advocates";
 
 export async function GET() {
-  // Uncomment this line to use a database
-  // const data = await db.select().from(advocates);
-
-  const data = advocateData;
+  const data = await db.select().from(advocates);
+  console.log({ data })
 
   return Response.json({ data });
 }

--- a/src/app/api/advocates/route.ts
+++ b/src/app/api/advocates/route.ts
@@ -1,9 +1,32 @@
+import { NextRequest, NextResponse } from "next/server";
 import db from "../../../db";
 import { advocates } from "../../../db/schema";
+import { sql } from "drizzle-orm";
 
-export async function GET() {
-  const data = await db.select().from(advocates);
-  console.log({ data })
+export async function GET(request: NextRequest) {
+  const searchParams = request.nextUrl.searchParams;
+  const searchQuery = searchParams.get("searchTerm") ?? "";
+  console.log("Search Query:", searchQuery);
 
-  return Response.json({ data });
+  try {
+    if (!searchQuery) {
+      const data = await db.select().from(advocates);
+      return NextResponse.json({ data, status: 200, ok: true });
+    }
+    const data = await db.select().from(advocates).where(sql`(
+      setweight(to_tsvector('english', ${advocates.firstName}), 'A') ||
+      setweight(to_tsvector('english', ${advocates.lastName}), 'A') ||
+      setweight(to_tsvector('english', ${advocates.city}), 'B') ||
+      setweight(to_tsvector('english', ${advocates.degree}), 'B') ||
+      setweight(to_tsvector('english', ${advocates.specialties}), 'C') ||
+      setweight(to_tsvector('english', ${advocates.yearsOfExperience}::text), 'D') ||
+      setweight(to_tsvector('english', ${advocates.phoneNumber}::text), 'D')
+      @@ to_tsquery('english', ${searchQuery})
+    )`);
+    console.log("New Data:", { newData: data });
+    return NextResponse.json({ data, status: 200, ok: true });
+  } catch (error) {
+    console.log("Route handler error when fetching newData: ", error);
+    return NextResponse.json({ data: null, error: "Failed to fetch advocates", status: 500 });
+  }
 }

--- a/src/app/api/seed/route.ts
+++ b/src/app/api/seed/route.ts
@@ -5,7 +5,5 @@ import { advocateData } from "../../../db/seed/advocates";
 export async function POST() {
   const records = await db.insert(advocates).values(advocateData).returning();
 
-  console.log({ records });
-
   return Response.json({ advocates: records });
 }

--- a/src/app/api/seed/route.ts
+++ b/src/app/api/seed/route.ts
@@ -5,5 +5,7 @@ import { advocateData } from "../../../db/seed/advocates";
 export async function POST() {
   const records = await db.insert(advocates).values(advocateData).returning();
 
+  console.log({ records });
+
   return Response.json({ advocates: records });
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { Inter } from "next/font/google";
+import { AppProviders } from "@/components/AppProviders/AppProviders";
 import "./globals.css";
 
 const inter = Inter({ subsets: ["latin"] });
@@ -16,7 +17,9 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body className={inter.className}>{children}</body>
+      <body className={inter.className}>
+        <AppProviders>{children}</AppProviders>
+      </body>
     </html>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,11 +3,16 @@ import { typedFetch } from "@/utils/typedFetch";
 
 import { AdvocateListView } from "@/feature-components/AdvocateListView/AdvocateListView";
 
-export default async function Home() {
+export default async function Home({ searchParams }: { searchParams: { [key: string]: string | string[] | undefined } }) {
+  console.log("Search Params:", searchParams);
   let advocateList: SelectAdvocates[] = [];
   try {
+    const { searchTerm } = searchParams;
+    const url = `/advocates${searchTerm ? `?searchTerm=${searchTerm}` : ''}`;
+    console.log("RSC SearchTerm", { searchTerm });
+    console.log("RSC Fetching advocates with URL:", { url });
     const advocateData = await typedFetch<{ data: SelectAdvocates[] }>(
-      "/advocates"
+      url
     );
     if (advocateData?.data && advocateData.data.length) {
       advocateList = advocateList.concat(advocateData.data);
@@ -15,6 +20,7 @@ export default async function Home() {
   } catch (error) {
     console.warn("Error when fetching advocate list", error);
   }
+  // console.log("RSC advocate List:", { advocateList });
 
   return (
     <AdvocateListView advocates={advocateList} />

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,105 +1,22 @@
-"use client";
-
 import type { SelectAdvocates } from "@/db/schema";
 import { typedFetch } from "@/utils/typedFetch";
-import { useEffect, useState } from "react";
 
-export default function Home() {
-  const [searchTerm, setSearchTerm] = useState<string>();
-  const [advocates, setAdvocates] = useState<SelectAdvocates[]>([]);
-  const [filteredAdvocates, setFilteredAdvocates] = useState<SelectAdvocates[]>(
-    []
-  );
+import { AdvocateListView } from "@/feature-components/AdvocateListView/AdvocateListView";
 
-  useEffect(() => {
-    async function getAdvocates() {
-      try {
-        const advocateData = await typedFetch<{ data: SelectAdvocates[] }>(
-          "/api/advocates"
-        );
-        if (advocateData?.data && advocateData.data.length) {
-          setAdvocates(advocateData.data);
-          setFilteredAdvocates(advocateData.data);
-        }
-      } catch (error) {
-        console.warn('Error when fetching advocate list', error)
-      }
+export default async function Home() {
+  let advocateList: SelectAdvocates[] = [];
+  try {
+    const advocateData = await typedFetch<{ data: SelectAdvocates[] }>(
+      "/advocates"
+    );
+    if (advocateData?.data && advocateData.data.length) {
+      advocateList = advocateList.concat(advocateData.data);
     }
-    getAdvocates();
-  }, []);
-
-  const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const searchTerm = e.target.value.trim()?.toLowerCase();
-    setSearchTerm(searchTerm);
-
-    const filteredAdvocates = advocates.filter((advocate) => {
-      return (
-        advocate.firstName.toLowerCase().includes(searchTerm) ||
-        advocate.lastName.toLowerCase().includes(searchTerm) ||
-        advocate.city.toLowerCase().includes(searchTerm) ||
-        advocate.degree.toLowerCase().includes(searchTerm) ||
-        advocate.specialties.some((s) =>
-          s.toLowerCase().includes(searchTerm)
-        ) ||
-        advocate.yearsOfExperience.toString().includes(searchTerm)
-      );
-    });
-
-    setFilteredAdvocates(filteredAdvocates);
-  };
-
-  const onClick = () => {
-    setFilteredAdvocates(advocates);
-    setSearchTerm('')
-  };
+  } catch (error) {
+    console.warn("Error when fetching advocate list", error);
+  }
 
   return (
-    <main style={{ margin: "24px" }}>
-      <h1>Solace Advocates</h1>
-      <br />
-      <br />
-      <div>
-        <p>Search</p>
-        <p>
-          Searching for: <span id="search-term">{searchTerm}</span>
-        </p>
-        <input style={{ border: "1px solid black" }} onChange={onChange} value={searchTerm} />
-        <button onClick={onClick}>Reset Search</button>
-      </div>
-      <br />
-      <br />
-      <table>
-        <thead>
-          <tr>
-            <th>First Name</th>
-            <th>Last Name</th>
-            <th>City</th>
-            <th>Degree</th>
-            <th>Specialties</th>
-            <th>Years of Experience</th>
-            <th>Phone Number</th>
-          </tr>
-        </thead>
-        <tbody>
-          {filteredAdvocates.map((advocate) => {
-            return (
-              <tr key={advocate.id}>
-                <td>{advocate.firstName}</td>
-                <td>{advocate.lastName}</td>
-                <td>{advocate.city}</td>
-                <td>{advocate.degree}</td>
-                <td>
-                  {advocate.specialties.map((s) => (
-                    <div key={s}>{s}</div>
-                  ))}
-                </td>
-                <td>{advocate.yearsOfExperience}</td>
-                <td>{advocate.phoneNumber}</td>
-              </tr>
-            );
-          })}
-        </tbody>
-      </table>
-    </main>
+    <AdvocateListView advocates={advocateList} />
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,13 +4,10 @@ import { typedFetch } from "@/utils/typedFetch";
 import { AdvocateListView } from "@/feature-components/AdvocateListView/AdvocateListView";
 
 export default async function Home({ searchParams }: { searchParams: { [key: string]: string | string[] | undefined } }) {
-  console.log("Search Params:", searchParams);
   let advocateList: SelectAdvocates[] = [];
   try {
     const { searchTerm } = searchParams;
     const url = `/advocates${searchTerm ? `?searchTerm=${searchTerm}` : ''}`;
-    console.log("RSC SearchTerm", { searchTerm });
-    console.log("RSC Fetching advocates with URL:", { url });
     const advocateData = await typedFetch<{ data: SelectAdvocates[] }>(
       url
     );
@@ -20,7 +17,6 @@ export default async function Home({ searchParams }: { searchParams: { [key: str
   } catch (error) {
     console.warn("Error when fetching advocate list", error);
   }
-  // console.log("RSC advocate List:", { advocateList });
 
   return (
     <AdvocateListView advocates={advocateList} />

--- a/src/components/AppProviders/AppProviders.tsx
+++ b/src/components/AppProviders/AppProviders.tsx
@@ -1,0 +1,8 @@
+"use client";
+
+import React from "react";
+import { AdvocateProvider } from "@/feature-components/AdvocateListView/advocate-context";
+
+export function AppProviders({ children }: { children: React.ReactNode }) {
+  return <AdvocateProvider>{children}</AdvocateProvider>;
+}

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -8,11 +8,18 @@ const setup = () => {
       select: () => ({
         from: () => [],
       }),
+      insert: () => ({
+        values: () => ({
+          returning: () => [],
+        }),
+      }),
     };
   }
 
   // for query purposes
-  const queryClient = postgres(process.env.DATABASE_URL);
+  const queryClient = postgres(process.env.DATABASE_URL, {
+    database: "solaceassignment",
+  });
   const db = drizzle(queryClient);
   return db;
 };

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -1,26 +1,17 @@
+import 'dotenv/config';
 import { drizzle } from "drizzle-orm/postgres-js";
 import postgres from "postgres";
+import * as schema from "./schema";
 
 const setup = () => {
-  if (!process.env.DATABASE_URL) {
-    console.error("DATABASE_URL is not set");
-    return {
-      select: () => ({
-        from: () => [],
-      }),
-      insert: () => ({
-        values: () => ({
-          returning: () => [],
-        }),
-      }),
-    };
-  }
-
   // for query purposes
-  const queryClient = postgres(process.env.DATABASE_URL, {
+  const queryClient = postgres(process.env.DATABASE_URL!, {
     database: "solaceassignment",
+    fetch_types: true,
   });
-  const db = drizzle(queryClient);
+  const db = drizzle(queryClient, {
+    schema: schema,
+  });
   return db;
 };
 

--- a/src/db/migrate.js
+++ b/src/db/migrate.js
@@ -1,15 +1,16 @@
 const { drizzle } = require("drizzle-orm/postgres-js");
 const { migrate } = require("drizzle-orm/postgres-js/migrator");
 const postgres = require("postgres");
+require("dotenv").config();
 
 const runMigration = async () => {
   if (!process.env.DATABASE_URL) throw new Error("DATABASE_URL is not set");
 
   console.log(process.env.DATABASE_URL);
 
-  const sql = postgres(process.env.DATABASE_URL, { max: 1 });
+  const sql = postgres(process.env.DATABASE_URL, { max: 1, database: "solaceassignment" });
   const db = drizzle(sql);
-  await migrate(db, { migrationsFolder: "drizzle" });
+  await migrate(db, { migrationsFolder: "src/db/migrations" });
   await sql.end();
 };
 

--- a/src/db/migrate.js
+++ b/src/db/migrate.js
@@ -6,8 +6,6 @@ require("dotenv").config();
 const runMigration = async () => {
   if (!process.env.DATABASE_URL) throw new Error("DATABASE_URL is not set");
 
-  console.log(process.env.DATABASE_URL);
-
   const sql = postgres(process.env.DATABASE_URL, { max: 1, database: "solaceassignment" });
   const db = drizzle(sql);
   await migrate(db, { migrationsFolder: "src/db/migrations" });

--- a/src/db/migrations/0000_previous_fantastic_four.sql
+++ b/src/db/migrations/0000_previous_fantastic_four.sql
@@ -1,0 +1,13 @@
+CREATE SCHEMA "SolaceHealth";
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "SolaceHealth"."advocates" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"first_name" text NOT NULL,
+	"last_name" text NOT NULL,
+	"city" text NOT NULL,
+	"degree" text NOT NULL,
+	"payload" jsonb DEFAULT '[]'::jsonb NOT NULL,
+	"years_of_experience" integer NOT NULL,
+	"phone_number" bigint NOT NULL,
+	"created_at" timestamp DEFAULT CURRENT_TIMESTAMP
+);

--- a/src/db/migrations/0001_aromatic_gwen_stacy.sql
+++ b/src/db/migrations/0001_aromatic_gwen_stacy.sql
@@ -1,0 +1,9 @@
+CREATE INDEX IF NOT EXISTS "search_index" ON "SolaceHealth"."advocates" USING gin ((
+      setweight(to_tsvector('english', "first_name"), 'A') ||
+      setweight(to_tsvector('english', "last_name"), 'A') ||
+      setweight(to_tsvector('english', "city"), 'B') ||
+      setweight(to_tsvector('english', "degree"), 'B') ||
+      setweight(to_tsvector('english', "payload"), 'C') ||
+      setweight(to_tsvector('english', "years_of_experience"::text), 'D') ||
+      setweight(to_tsvector('english', "phone_number"::text), 'D')
+    ));

--- a/src/db/migrations/meta/0000_snapshot.json
+++ b/src/db/migrations/meta/0000_snapshot.json
@@ -1,0 +1,84 @@
+{
+  "id": "c486d0a0-ad32-4f32-bd3f-880bc74a6050",
+  "prevId": "00000000-0000-0000-0000-000000000000",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "SolaceHealth.advocates": {
+      "name": "advocates",
+      "schema": "SolaceHealth",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "city": {
+          "name": "city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "degree": {
+          "name": "degree",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "years_of_experience": {
+          "name": "years_of_experience",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone_number": {
+          "name": "phone_number",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    }
+  },
+  "enums": {},
+  "schemas": {
+    "SolaceHealth": "SolaceHealth"
+  },
+  "sequences": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/src/db/migrations/meta/0001_snapshot.json
+++ b/src/db/migrations/meta/0001_snapshot.json
@@ -1,0 +1,100 @@
+{
+  "id": "87690f49-503f-44e5-8494-99261f49fbc7",
+  "prevId": "c486d0a0-ad32-4f32-bd3f-880bc74a6050",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "SolaceHealth.advocates": {
+      "name": "advocates",
+      "schema": "SolaceHealth",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "city": {
+          "name": "city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "degree": {
+          "name": "degree",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "years_of_experience": {
+          "name": "years_of_experience",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone_number": {
+          "name": "phone_number",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "search_index": {
+          "name": "search_index",
+          "columns": [
+            {
+              "expression": "(\n      setweight(to_tsvector('english', \"first_name\"), 'A') ||\n      setweight(to_tsvector('english', \"last_name\"), 'A') ||\n      setweight(to_tsvector('english', \"city\"), 'B') ||\n      setweight(to_tsvector('english', \"degree\"), 'B') ||\n      setweight(to_tsvector('english', \"payload\"), 'C') ||\n      setweight(to_tsvector('english', \"years_of_experience\"::text), 'D') ||\n      setweight(to_tsvector('english', \"phone_number\"::text), 'D')\n    )",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    }
+  },
+  "enums": {},
+  "schemas": {
+    "SolaceHealth": "SolaceHealth"
+  },
+  "sequences": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/src/db/migrations/meta/_journal.json
+++ b/src/db/migrations/meta/_journal.json
@@ -1,0 +1,13 @@
+{
+  "version": "7",
+  "dialect": "postgresql",
+  "entries": [
+    {
+      "idx": 0,
+      "version": "7",
+      "when": 1755225649584,
+      "tag": "0000_previous_fantastic_four",
+      "breakpoints": true
+    }
+  ]
+}

--- a/src/db/migrations/meta/_journal.json
+++ b/src/db/migrations/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1755225649584,
       "tag": "0000_previous_fantastic_four",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1755325430259,
+      "tag": "0001_aromatic_gwen_stacy",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -1,4 +1,4 @@
-import { sql, type InferSelectModel  } from "drizzle-orm";
+import { sql, type InferSelectModel } from "drizzle-orm";
 import {
   pgSchema,
   integer,
@@ -7,22 +7,39 @@ import {
   serial,
   timestamp,
   bigint,
+  index,
 } from "drizzle-orm/pg-core";
 
-export const solaceHealthSchema = pgSchema('SolaceHealth');
+export const solaceHealthSchema = pgSchema("SolaceHealth");
 
-const advocates = solaceHealthSchema.table("advocates", {
-  id: serial("id").primaryKey(),
-  firstName: text("first_name").notNull(),
-  lastName: text("last_name").notNull(),
-  city: text("city").notNull(),
-  degree: text("degree").notNull(),
-  specialties: jsonb("payload").default([]).notNull().$type<string[]>(),
-  yearsOfExperience: integer("years_of_experience").notNull(),
-  phoneNumber: bigint("phone_number", { mode: "number" }).notNull(),
-  createdAt: timestamp("created_at").default(sql`CURRENT_TIMESTAMP`),
-});
+export const advocates = solaceHealthSchema.table(
+  "advocates",
+  {
+    id: serial("id").primaryKey(),
+    firstName: text("first_name").notNull(),
+    lastName: text("last_name").notNull(),
+    city: text("city").notNull(),
+    degree: text("degree").notNull(),
+    specialties: jsonb("payload").default([]).notNull().$type<string[]>(),
+    yearsOfExperience: integer("years_of_experience").notNull(),
+    phoneNumber: bigint("phone_number", { mode: "number" }).notNull(),
+    createdAt: timestamp("created_at").default(sql`CURRENT_TIMESTAMP`),
+  },
+  // https://github.com/drizzle-team/drizzle-orm/issues/3873
+  // Wasn't able to generate indexes unless I used the following syntax
+  // @ts-expect-error Type 'IndexBuilder[]' is not assignable to type 'PgTableExtraConfig'.
+  //  Index signature for type 'string' is missing in type 'IndexBuilder[]'.ts(2345)
+  (table) => [
+    index('search_index').using('gin', sql`(
+      setweight(to_tsvector('english', ${table.firstName}), 'A') ||
+      setweight(to_tsvector('english', ${table.lastName}), 'A') ||
+      setweight(to_tsvector('english', ${table.city}), 'B') ||
+      setweight(to_tsvector('english', ${table.degree}), 'B') ||
+      setweight(to_tsvector('english', ${table.specialties}), 'C') ||
+      setweight(to_tsvector('english', ${table.yearsOfExperience}), 'D') ||
+      setweight(to_tsvector('english', ${table.phoneNumber}), 'D')
+    )`),
+  ],
+);
 
-type SelectAdvocates = InferSelectModel<typeof advocates>;
-
-export { advocates, type SelectAdvocates };
+export type SelectAdvocates = InferSelectModel<typeof advocates>;

--- a/src/feature-components/AdvocateListView/AdvocateList/AdvocateList.tsx
+++ b/src/feature-components/AdvocateListView/AdvocateList/AdvocateList.tsx
@@ -1,0 +1,44 @@
+'use client';
+
+import React, { useState } from "react";
+
+import { useAdvocateContext } from "../advocate-context";
+
+export function AdvocateList() {
+  const { filteredAdvocates } = useAdvocateContext();
+
+  return (
+    <table>
+      <thead>
+        <tr>
+          <th>First Name</th>
+          <th>Last Name</th>
+          <th>City</th>
+          <th>Degree</th>
+          <th>Specialties</th>
+          <th>Years of Experience</th>
+          <th>Phone Number</th>
+        </tr>
+      </thead>
+      <tbody>
+        {filteredAdvocates.map((advocate) => {
+          return (
+            <tr key={advocate.id}>
+              <td>{advocate.firstName}</td>
+              <td>{advocate.lastName}</td>
+              <td>{advocate.city}</td>
+              <td>{advocate.degree}</td>
+              <td>
+                {advocate.specialties.map((s) => (
+                  <div key={s}>{s}</div>
+                ))}
+              </td>
+              <td>{advocate.yearsOfExperience}</td>
+              <td>{advocate.phoneNumber}</td>
+            </tr>
+          );
+        })}
+      </tbody>
+    </table>
+  );
+}

--- a/src/feature-components/AdvocateListView/AdvocateList/AdvocateList.tsx
+++ b/src/feature-components/AdvocateListView/AdvocateList/AdvocateList.tsx
@@ -1,11 +1,11 @@
 'use client';
 
-import React, { useState } from "react";
+import React from "react";
 
 import { useAdvocateContext } from "../advocate-context";
 
 export function AdvocateList() {
-  const { filteredAdvocates } = useAdvocateContext();
+  const { advocates } = useAdvocateContext();
 
   return (
     <table>
@@ -21,7 +21,7 @@ export function AdvocateList() {
         </tr>
       </thead>
       <tbody>
-        {filteredAdvocates.map((advocate) => {
+        {advocates.map((advocate) => {
           return (
             <tr key={advocate.id}>
               <td>{advocate.firstName}</td>

--- a/src/feature-components/AdvocateListView/AdvocateListView.tsx
+++ b/src/feature-components/AdvocateListView/AdvocateListView.tsx
@@ -15,7 +15,6 @@ export function AdvocateListView({ advocates }: AdvocateListViewProps) {
   const { setAdvocates } = useAdvocateContext();
 
   useEffect(() => {
-    console.log({ advocates });
     setAdvocates(advocates);
   }, [advocates, setAdvocates]);
 

--- a/src/feature-components/AdvocateListView/AdvocateListView.tsx
+++ b/src/feature-components/AdvocateListView/AdvocateListView.tsx
@@ -5,6 +5,7 @@ import { useAdvocateContext } from "./advocate-context";
 import { AdvocateList } from "./AdvocateList/AdvocateList";
 
 import type { SelectAdvocates } from "@/db/schema";
+import { AdvocateSearch } from "./AdvocateSearch/AdvocateSearch";
 
 interface AdvocateListViewProps {
   advocates: SelectAdvocates[];
@@ -21,6 +22,9 @@ export function AdvocateListView({ advocates }: AdvocateListViewProps) {
   return (
     <main style={{ margin: "24px" }}>
       <h1>Solace Advocates</h1>
+      <br />
+      <br />
+      <AdvocateSearch />
       <br />
       <br />
       <AdvocateList />

--- a/src/feature-components/AdvocateListView/AdvocateListView.tsx
+++ b/src/feature-components/AdvocateListView/AdvocateListView.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import React, { useEffect } from "react";
+import { useAdvocateContext } from "./advocate-context";
+import { AdvocateList } from "./AdvocateList/AdvocateList";
+
+import type { SelectAdvocates } from "@/db/schema";
+
+interface AdvocateListViewProps {
+  advocates: SelectAdvocates[];
+}
+
+export function AdvocateListView({ advocates }: AdvocateListViewProps) {
+  const { setAdvocates } = useAdvocateContext();
+
+  useEffect(() => {
+    console.log({ advocates });
+    setAdvocates(advocates);
+  }, [advocates, setAdvocates]);
+
+  return (
+    <main style={{ margin: "24px" }}>
+      <h1>Solace Advocates</h1>
+      <br />
+      <br />
+      <AdvocateList />
+      <br />
+      <br />
+    </main>
+  );
+}

--- a/src/feature-components/AdvocateListView/AdvocateSearch/AdvocateSearch.tsx
+++ b/src/feature-components/AdvocateListView/AdvocateSearch/AdvocateSearch.tsx
@@ -9,7 +9,7 @@ export function AdvocateSearch() {
     useAdvocateContext();
 
   const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const searchTerm = e.target.value.trim()?.toLowerCase();
+    const searchTerm = e.target.value.toLowerCase();
     setSearchTerm(searchTerm);
   };
 
@@ -21,7 +21,7 @@ export function AdvocateSearch() {
     <div>
       <p>Search</p>
       <p>
-        Searching for: <span id="search-term">{searchTerm}</span>
+        Searching for: <span id="search-term">{searchTerm.trim()}</span>
       </p>
       <input
         style={{ border: "1px solid black" }}

--- a/src/feature-components/AdvocateListView/AdvocateSearch/AdvocateSearch.tsx
+++ b/src/feature-components/AdvocateListView/AdvocateSearch/AdvocateSearch.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import React from "react";
+
+import { useAdvocateContext } from "../advocate-context";
+
+export function AdvocateSearch() {
+  const { searchTerm, setSearchTerm } =
+    useAdvocateContext();
+
+  const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const searchTerm = e.target.value.trim()?.toLowerCase();
+    setSearchTerm(searchTerm);
+  };
+
+  const onClick = () => {
+    setSearchTerm("");
+  };
+
+  return (
+    <div>
+      <p>Search</p>
+      <p>
+        Searching for: <span id="search-term">{searchTerm}</span>
+      </p>
+      <input
+        style={{ border: "1px solid black" }}
+        onChange={onChange}
+        value={searchTerm}
+      />
+      <button onClick={onClick}>Reset Search</button>
+    </div>
+  );
+}

--- a/src/feature-components/AdvocateListView/advocate-context.tsx
+++ b/src/feature-components/AdvocateListView/advocate-context.tsx
@@ -34,16 +34,17 @@ export const AdvocateProvider: React.FC<{ children: React.ReactNode }> = ({
   }, [advocates]);
 
   const filteredAdvocates = useMemo(() => {
+    const trimmedSearchTerm = searchTerm.trim();
     return advocates.filter((advocate) => {
       return (
-        advocate.firstName.toLowerCase().includes(searchTerm) ||
-        advocate.lastName.toLowerCase().includes(searchTerm) ||
-        advocate.city.toLowerCase().includes(searchTerm) ||
-        advocate.degree.toLowerCase().includes(searchTerm) ||
+        advocate.firstName.toLowerCase().includes(trimmedSearchTerm) ||
+        advocate.lastName.toLowerCase().includes(trimmedSearchTerm) ||
+        advocate.city.toLowerCase().includes(trimmedSearchTerm) ||
+        advocate.degree.toLowerCase().includes(trimmedSearchTerm) ||
         advocate.specialties.some((s) =>
-          s.toLowerCase().includes(searchTerm)
+          s.toLowerCase().includes(trimmedSearchTerm)
         ) ||
-        advocate.yearsOfExperience.toString().includes(searchTerm)
+        advocate.yearsOfExperience.toString().includes(trimmedSearchTerm)
       );
     });
   }, [advocates, searchTerm]);

--- a/src/feature-components/AdvocateListView/advocate-context.tsx
+++ b/src/feature-components/AdvocateListView/advocate-context.tsx
@@ -1,0 +1,68 @@
+import React, { createContext, useContext, useEffect, useMemo } from "react";
+
+import type { SelectAdvocates } from "@/db/schema";
+
+export interface AdvocateContextType {
+  searchTerm: string;
+  setSearchTerm: (term: string) => void;
+  advocates: SelectAdvocates[];
+  setAdvocates: React.Dispatch<React.SetStateAction<SelectAdvocates[]>>;
+  filteredAdvocates: SelectAdvocates[];
+//   setFilteredAdvocates: React.Dispatch<React.SetStateAction<SelectAdvocates[]>>;
+}
+
+export const AdvocateContext = createContext<AdvocateContextType | null>(
+  null
+);
+
+export const useAdvocateContext = (): AdvocateContextType => {
+  const context = useContext(AdvocateContext);
+  if (!context) {
+    throw new Error(
+      "useAdvocateContext must be used within an AdvocateProvider"
+    );
+  }
+  return context;
+};
+export const AdvocateProvider: React.FC<{ children: React.ReactNode }> = ({
+  children,
+}) => {
+  const [searchTerm, setSearchTerm] = React.useState<string>("");
+  const [advocates, setAdvocates] = React.useState<SelectAdvocates[]>([]);
+//   const [filteredAdvocates, setFilteredAdvocates] = React.useState<
+//     SelectAdvocates[]
+//   >([]);
+
+  useEffect(() => {
+    console.log("Advocates updated:", advocates);
+  }, [advocates]);
+
+  const filteredAdvocates = useMemo(() => {
+    return advocates.filter((advocate) => {
+      return (
+        advocate.firstName.toLowerCase().includes(searchTerm) ||
+        advocate.lastName.toLowerCase().includes(searchTerm) ||
+        advocate.city.toLowerCase().includes(searchTerm) ||
+        advocate.degree.toLowerCase().includes(searchTerm) ||
+        advocate.specialties.some((s) =>
+          s.toLowerCase().includes(searchTerm)
+        ) ||
+        advocate.yearsOfExperience.toString().includes(searchTerm)
+      );
+    });
+  }, [advocates, searchTerm]);
+
+  return (
+    <AdvocateContext.Provider
+      value={{
+        searchTerm,
+        setSearchTerm,
+        advocates,
+        setAdvocates,
+        filteredAdvocates,
+      }}
+    >
+      {children}
+    </AdvocateContext.Provider>
+  );
+};

--- a/src/feature-components/AdvocateListView/advocate-context.tsx
+++ b/src/feature-components/AdvocateListView/advocate-context.tsx
@@ -1,23 +1,25 @@
-import { useSearchParams, usePathname } from 'next/navigation'
+import { useSearchParams, usePathname } from "next/navigation";
 
-import React, { createContext, useCallback, useContext, useEffect } from "react";
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+} from "react";
 
-import { useDebouncedCallback } from 'use-debounce'
+import { useDebouncedCallback } from "use-debounce";
 
 import type { SelectAdvocates } from "@/db/schema";
-import { typedFetch } from '@/utils/typedFetch';
+import { typedFetch } from "@/utils/typedFetch";
 
 export interface AdvocateContextType {
   searchTerm: string;
   setSearchTerm: (term: string) => void;
   advocates: SelectAdvocates[];
   setAdvocates: React.Dispatch<React.SetStateAction<SelectAdvocates[]>>;
-  filteredAdvocates: SelectAdvocates[];
 }
 
-export const AdvocateContext = createContext<AdvocateContextType | null>(
-  null
-);
+export const AdvocateContext = createContext<AdvocateContextType | null>(null);
 
 export const useAdvocateContext = (): AdvocateContextType => {
   const context = useContext(AdvocateContext);
@@ -28,28 +30,17 @@ export const useAdvocateContext = (): AdvocateContextType => {
   }
   return context;
 };
+
 export const AdvocateProvider: React.FC<{ children: React.ReactNode }> = ({
   children,
 }) => {
   const searchParams = useSearchParams();
   const pathname = usePathname();
-
-  const handleUpdateSearchParams = useCallback((trimmedSearchTerm: string) => {
-    const params = new URLSearchParams(searchParams);
-    console.log({ trimmedSearchTerm })
-    if (trimmedSearchTerm) {
-      params.set('searchTerm', trimmedSearchTerm);
-    } else {
-      params.delete('searchTerm');
-    }
-    console.log("Updated Search Params:", { params: params,  paramsSize: params.size, paramsString: params.toString() });
-    window.history.pushState(null, '', `${params.size ? `?${params.toString()}` : ''}`)
-  }, [searchParams]);
+  console.log({ pathname });
 
   const getAdvocates = async (searchTerm: string) => {
     try {
-      // const searchQuery = searchParams.get('searchTerm') || '';
-      const url = `/advocates${searchTerm ? `?searchTerm=${searchTerm}` : ''}`;
+      const url = `/advocates${searchTerm ? `?searchTerm=${searchTerm}` : ""}`;
       console.log("Fetching advocates with URL:", url);
       const data = await typedFetch<{ data: SelectAdvocates[] }>(url);
       if (data?.data && data.data.length) {
@@ -65,10 +56,35 @@ export const AdvocateProvider: React.FC<{ children: React.ReactNode }> = ({
   const throttledCallback = useDebouncedCallback((searchTerm: string) => {
     console.log("Throttled search term:", searchTerm);
     getAdvocates(searchTerm);
-  }, 500);
+  }, 800);
 
-  const [searchTerm, setSearchTerm] = React.useState<string>(searchParams.get('searchTerm') || '');
+  const [searchTerm, setSearchTerm] = React.useState<string>(
+    searchParams.get("searchTerm") || ""
+  );
   const [advocates, setAdvocates] = React.useState<SelectAdvocates[]>([]);
+
+  const handleUpdateSearchParams = useCallback(
+    (trimmedSearchTerm: string) => {
+      const params = new URLSearchParams(searchParams);
+      console.log({ trimmedSearchTerm });
+      if (trimmedSearchTerm) {
+        params.set("searchTerm", trimmedSearchTerm);
+      } else {
+        params.delete("searchTerm");
+      }
+      console.log("Updated Search Params:", {
+        params: params,
+        paramsSize: params.size,
+        paramsString: params.toString(),
+      });
+      window.history.pushState(
+        null,
+        "",
+        `${pathname}${params.has("searchTerm") ? `?${params.toString()}` : ""}`
+      );
+    },
+    [pathname, searchParams]
+  );
 
   useEffect(() => {
     console.log("Advocates updated:", advocates);
@@ -76,12 +92,9 @@ export const AdvocateProvider: React.FC<{ children: React.ReactNode }> = ({
 
   useEffect(() => {
     const trimmedSearchTerm = searchTerm.trim();
-    console.log("Search Term:", trimmedSearchTerm);
     handleUpdateSearchParams(trimmedSearchTerm);
-    if (pathname === '/') {
-      throttledCallback(trimmedSearchTerm);
-    }
-  }, [searchTerm, pathname, throttledCallback, handleUpdateSearchParams])
+    throttledCallback(trimmedSearchTerm);
+  }, [searchTerm, pathname, throttledCallback, handleUpdateSearchParams]);
 
   return (
     <AdvocateContext.Provider
@@ -90,11 +103,9 @@ export const AdvocateProvider: React.FC<{ children: React.ReactNode }> = ({
         setSearchTerm,
         advocates,
         setAdvocates,
-        filteredAdvocates: advocates,
       }}
     >
       {children}
     </AdvocateContext.Provider>
   );
 };
-

--- a/src/feature-components/AdvocateListView/advocate-context.tsx
+++ b/src/feature-components/AdvocateListView/advocate-context.tsx
@@ -8,7 +8,6 @@ export interface AdvocateContextType {
   advocates: SelectAdvocates[];
   setAdvocates: React.Dispatch<React.SetStateAction<SelectAdvocates[]>>;
   filteredAdvocates: SelectAdvocates[];
-//   setFilteredAdvocates: React.Dispatch<React.SetStateAction<SelectAdvocates[]>>;
 }
 
 export const AdvocateContext = createContext<AdvocateContextType | null>(
@@ -29,9 +28,6 @@ export const AdvocateProvider: React.FC<{ children: React.ReactNode }> = ({
 }) => {
   const [searchTerm, setSearchTerm] = React.useState<string>("");
   const [advocates, setAdvocates] = React.useState<SelectAdvocates[]>([]);
-//   const [filteredAdvocates, setFilteredAdvocates] = React.useState<
-//     SelectAdvocates[]
-//   >([]);
 
   useEffect(() => {
     console.log("Advocates updated:", advocates);

--- a/src/feature-components/AdvocateListView/advocate-context.tsx
+++ b/src/feature-components/AdvocateListView/advocate-context.tsx
@@ -36,12 +36,10 @@ export const AdvocateProvider: React.FC<{ children: React.ReactNode }> = ({
 }) => {
   const searchParams = useSearchParams();
   const pathname = usePathname();
-  console.log({ pathname });
 
   const getAdvocates = async (searchTerm: string) => {
     try {
       const url = `/advocates${searchTerm ? `?searchTerm=${searchTerm}` : ""}`;
-      console.log("Fetching advocates with URL:", url);
       const data = await typedFetch<{ data: SelectAdvocates[] }>(url);
       if (data?.data && data.data.length) {
         setAdvocates(data.data);
@@ -54,7 +52,6 @@ export const AdvocateProvider: React.FC<{ children: React.ReactNode }> = ({
   };
 
   const throttledCallback = useDebouncedCallback((searchTerm: string) => {
-    console.log("Throttled search term:", searchTerm);
     getAdvocates(searchTerm);
   }, 800);
 
@@ -66,17 +63,12 @@ export const AdvocateProvider: React.FC<{ children: React.ReactNode }> = ({
   const handleUpdateSearchParams = useCallback(
     (trimmedSearchTerm: string) => {
       const params = new URLSearchParams(searchParams);
-      console.log({ trimmedSearchTerm });
       if (trimmedSearchTerm) {
         params.set("searchTerm", trimmedSearchTerm);
       } else {
         params.delete("searchTerm");
       }
-      console.log("Updated Search Params:", {
-        params: params,
-        paramsSize: params.size,
-        paramsString: params.toString(),
-      });
+      
       window.history.pushState(
         null,
         "",
@@ -85,10 +77,6 @@ export const AdvocateProvider: React.FC<{ children: React.ReactNode }> = ({
     },
     [pathname, searchParams]
   );
-
-  useEffect(() => {
-    console.log("Advocates updated:", advocates);
-  }, [advocates]);
 
   useEffect(() => {
     const trimmedSearchTerm = searchTerm.trim();

--- a/src/utils/typedFetch.ts
+++ b/src/utils/typedFetch.ts
@@ -1,5 +1,9 @@
+import 'dotenv/config';
+
+const baseUrl = process.env.NEXT_PUBLIC_API_BASE_URL;
+
 export async function typedFetch<T>(url: string, options?: RequestInit): Promise<T> {
-  const response = await fetch(url, options);
+  const response = await fetch(`${baseUrl}${url}`, options);
 
   if (!response.ok) {
     // Handle HTTP errors (e.g., 404, 500)


### PR DESCRIPTION
This PR

- uses the postgres DB to retrieve the advocate list instead of the constant and creates/applies migrations and seeds the DB.
- slightly refactors the route handler at `/api/advocates` to use URL search params to filter advocate data at the SQL query level rather than on the front end to account for the potential to have hundreds or thousands of rows
- leverages Next's React server components to retrieve the advocate list on the server-side on initial render and app-reload
- refactors the client side portion into various components organized in a hierarchical pattern to reflect the relationships between them
- uses a context to store application state and make requests to the route handler at `/api/advocates`